### PR TITLE
[FIX] Change to only use environment variable when asked for.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,9 @@ The custom options are:
 * ``--odoo-config``: path of the odoo.cfg file to use.
 * ``--odoo-http``: Allow to launch the Odoo http instance
 * ``--odoo-skip-at-install``: use to skip tests that are decorated with `@tagged("at_install")` (*Note*: this is not the default behavior because Odoo set this tag by default if not defined).
+* ``--odoo-db-use-env-vars``: use environment variables. Using environment variables can also be achieved by setting the environment variable ``PYTEST_DB_USE_ENV_VARS`` to ``true``.
 
-
-Alternatively, you can use environment variables, like the Odoo Docker image:
-
+When using environment variables, they are the same as the Odoo Docker image:
 * ``HOST``: hostname of the database server
 * ``PORT``: port of the database server
 * ``USER``: username to access the database

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -52,6 +52,11 @@ def pytest_addoption(parser):
     parser.addoption("--odoo-skip-at-install",
                      action="store_true",
                      help="If pytest should skip tests marked with at_install.")
+    parser.addoption(
+        "--odoo-db-use-env-vars",
+        action="store_true",
+        help="If HOST, PORT, USER and PASSWORD environment variables should be used.",
+    )
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -84,9 +89,15 @@ def pytest_cmdline_main(config):
 
         # Check the environment variables supported by the Odoo Docker image
         # ref: https://hub.docker.com/_/odoo
-        for arg in ['HOST', 'PORT', 'USER', 'PASSWORD']:
-            if os.environ.get(arg):
-                options.append('--db_%s=%s' % (arg.lower(), os.environ.get(arg)))
+        use_env: str | None = (
+            os.environ.get("PYTEST_DB_USE_ENV_VARS").lowercase()
+            if os.environ.get("PYTEST_DB_USE_ENV_VARS")
+            else None
+        )
+        if config.getoption("--odoo-db-use-env-vars") or use_env == "true":
+            for arg in ["HOST", "PORT", "USER", "PASSWORD"]:
+                if os.environ.get(arg):
+                    options.append("--db_%s=%s" % (arg.lower(), os.environ.get(arg)))
 
         odoo.tools.config.parse_config(options)
 


### PR DESCRIPTION
In non Odoo SA docker environment, USER is the name of the local user and should not be used. Odoo and postgres expects and use PGUSER.

Solves #81

Implemented after comment https://github.com/camptocamp/pytest-odoo/pull/83#issuecomment-3727680607